### PR TITLE
Fix WebGL context client cluttering

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -36,9 +36,7 @@ export default class Skinview3d extends Component {
     }
 
     componentWillUnmount() {
-        this.setState({
-            viewer: null
-        });
+        this.state.viewer.renderer.forceContextLoss();
     }
 
     componentDidUpdate(prevProps) {


### PR DESCRIPTION
https://youtu.be/wVflakQPbHs
![image](https://user-images.githubusercontent.com/42776347/89729479-7e1dc680-da79-11ea-9db0-34591f63d978.png)

There is no need to remove a state, React does it itself when unmounting a component